### PR TITLE
Impl signals with write address

### DIFF
--- a/examples/sgemm.py
+++ b/examples/sgemm.py
@@ -26,7 +26,7 @@ def qpu_sgemm_rnn_naive(asm):
         g['reg_' + reg] = g['rf' + str(i)]
 
     for reg in ['A_i', 'B_i', 'C_j', 'alpha', 'beta', 'P', 'Q', 'R']:
-        nop(null, sig = 'ldunif')
+        nop(null, sig = ldunif)
         mov(g['reg_' + reg], r5)
 
     # B_i += 4 * eidx
@@ -57,21 +57,21 @@ def qpu_sgemm_rnn_naive(asm):
             L.loop_k
             if True:
 
-                mov(tmua, reg_A_k, sig = 'thrsw')
+                mov(tmua, reg_A_k, sig = thrsw)
                 sub(reg_k, reg_k, 1, cond = 'pushz')
-                mov(tmua, reg_B_k, sig = 'thrsw')
-                nop(r1, sig = 'ldtmu')
-                nop(r2, sig = 'ldtmu')
+                mov(tmua, reg_B_k, sig = thrsw)
+                nop(null, sig = ldtmu(r1))
+                nop(null, sig = ldtmu(r2))
 
                 b(R.loop_k, cond = 'anyna')
                 fmul(r1, r1, r2)
                 fadd(r0, r0, r1).add(reg_A_k, reg_A_k, 4)
                 add(reg_B_k, reg_B_k, reg_4_R)
 
-            mov(tmua, reg_C_j, sig = 'thrsw')
+            mov(tmua, reg_C_j, sig = thrsw)
             fmul(r0, r0, reg_alpha)
             sub(reg_j, reg_j, 1, cond = 'pushz')
-            nop(r1, sig = 'ldtmu')
+            nop(null, sig = ldtmu(r1))
             fmul(r1, r1, reg_beta)
 
             b(R.loop_j, cond = 'anyna')
@@ -85,11 +85,11 @@ def qpu_sgemm_rnn_naive(asm):
         nop(null)
         nop(null)
 
-    nop(null, sig = 'thrsw')
-    nop(null, sig = 'thrsw')
+    nop(null, sig = thrsw)
+    nop(null, sig = thrsw)
     nop(null)
     nop(null)
-    nop(null, sig = 'thrsw')
+    nop(null, sig = thrsw)
     nop(null)
     nop(null)
     nop(null)

--- a/tests/test_alu.py
+++ b/tests/test_alu.py
@@ -81,9 +81,9 @@ ops = {
 @qpu
 def qpu_binary_ops(asm, bin_ops, dst_ops, src1_ops, src2_ops):
 
-    eidx(r0, sig = 'ldunif')
-    mov(rf0, r5, sig = 'ldunif') # in
-    mov(rf1, r5, sig = 'ldunif')  # out
+    eidx(r0, sig = ldunif)
+    mov(rf0, r5, sig = ldunif) # in
+    mov(rf1, r5, sig = ldunif)  # out
     shl(r3, 4, 4).mov(rf2, r5)
 
     shl(r0, r0, 2)
@@ -91,12 +91,12 @@ def qpu_binary_ops(asm, bin_ops, dst_ops, src1_ops, src2_ops):
     add(rf1, rf1, r0)
     add(rf2, rf2, r0)
 
-    mov(tmua, rf0, sig = 'thrsw').add(rf0, rf0, r3)
+    mov(tmua, rf0, sig = thrsw).add(rf0, rf0, r3)
     nop(null)
-    mov(tmua, rf1, sig = 'thrsw').add(rf1, rf1, r3)
-    nop(r1, sig = 'ldtmu')
+    mov(tmua, rf1, sig = thrsw).add(rf1, rf1, r3)
+    nop(null, sig = ldtmu(r1))
     nop(null)
-    nop(r2, sig = 'ldtmu')
+    nop(null, sig = ldtmu(r2))
 
     g = globals()
     for op, pack, unpack1, unpack2 in itertools.product(bin_ops, dst_ops, src1_ops, src2_ops):
@@ -109,11 +109,11 @@ def qpu_binary_ops(asm, bin_ops, dst_ops, src1_ops, src2_ops):
         mov(tmua, rf2)
         tmuwt(null).add(rf2, rf2, r3)
 
-    nop(null, sig = 'thrsw')
-    nop(null, sig = 'thrsw')
+    nop(null, sig = thrsw)
+    nop(null, sig = thrsw)
     nop(null)
     nop(null)
-    nop(null, sig = 'thrsw')
+    nop(null, sig = thrsw)
     nop(null)
     nop(null)
     nop(null)
@@ -196,18 +196,18 @@ def test_binary_ops():
 @qpu
 def qpu_unary_ops(asm, bin_ops, dst_ops, src_ops):
 
-    eidx(r0, sig = 'ldunif')
-    mov(rf0, r5, sig = 'ldunif') # in
+    eidx(r0, sig = ldunif)
+    mov(rf0, r5, sig = ldunif) # in
     shl(r3, 4, 4).mov(rf1, r5)
 
     shl(r0, r0, 2)
     add(rf0, rf0, r0)
     add(rf1, rf1, r0)
 
-    mov(tmua, rf0, sig = 'thrsw').add(rf0, rf0, r3)
+    mov(tmua, rf0, sig = thrsw).add(rf0, rf0, r3)
     nop(null)
     nop(null)
-    nop(r1, sig = 'ldtmu')
+    nop(null, sig = ldtmu(r1))
 
     g = globals()
     for op, pack, unpack in itertools.product(bin_ops, dst_ops, src_ops):
@@ -219,11 +219,11 @@ def qpu_unary_ops(asm, bin_ops, dst_ops, src_ops):
         mov(tmua, rf1)
         tmuwt(null).add(rf1, rf1, r3)
 
-    nop(null, sig = 'thrsw')
-    nop(null, sig = 'thrsw')
+    nop(null, sig = thrsw)
+    nop(null, sig = thrsw)
     nop(null)
     nop(null)
-    nop(null, sig = 'thrsw')
+    nop(null, sig = thrsw)
     nop(null)
     nop(null)
     nop(null)

--- a/tests/test_condition_codes.py
+++ b/tests/test_condition_codes.py
@@ -9,7 +9,7 @@ import numpy as np
 @qpu
 def qpu_cond_push_a(asm):
 
-    eidx(r0, sig = 'ldunif')
+    eidx(r0, sig = ldunif)
     mov(r2, r5)
     shl(r0, r0, 2)
     add(r2, r2, r0)
@@ -35,11 +35,11 @@ def qpu_cond_push_a(asm):
         mov(tmua, r2)
         tmuwt(null).add(r2, r2, r1)
 
-    nop(null, sig = 'thrsw')
-    nop(null, sig = 'thrsw')
+    nop(null, sig = thrsw)
+    nop(null, sig = thrsw)
     nop(null)
     nop(null)
-    nop(null, sig = 'thrsw')
+    nop(null, sig = thrsw)
     nop(null)
     nop(null)
     nop(null)
@@ -80,7 +80,7 @@ def test_cond_push_a():
 @qpu
 def qpu_cond_push_b(asm):
 
-    eidx(r0, sig = 'ldunif')
+    eidx(r0, sig = ldunif)
     mov(r2, r5)
     shl(r0, r0, 2)
     add(r2, r2, r0)
@@ -115,11 +115,11 @@ def qpu_cond_push_b(asm):
     mov(tmua, r2)
     tmuwt(null).add(r2, r2, r1)
 
-    nop(null, sig = 'thrsw')
-    nop(null, sig = 'thrsw')
+    nop(null, sig = thrsw)
+    nop(null, sig = thrsw)
     nop(null)
     nop(null)
-    nop(null, sig = 'thrsw')
+    nop(null, sig = thrsw)
     nop(null)
     nop(null)
     nop(null)
@@ -162,7 +162,7 @@ def test_cond_push_b():
 @qpu
 def qpu_cond_update(asm, cond_update_flags):
 
-    eidx(r0, sig = 'ldunif')
+    eidx(r0, sig = ldunif)
     mov(r2, r5)
     shl(r0, r0, 2)
     add(r2, r2, r0)
@@ -190,11 +190,11 @@ def qpu_cond_update(asm, cond_update_flags):
         mov(tmua, r2)
         tmuwt(null).add(r2, r2, r1)
 
-    nop(null, sig = 'thrsw')
-    nop(null, sig = 'thrsw')
+    nop(null, sig = thrsw)
+    nop(null, sig = thrsw)
     nop(null)
     nop(null)
-    nop(null, sig = 'thrsw')
+    nop(null, sig = thrsw)
     nop(null)
     nop(null)
     nop(null)
@@ -249,7 +249,7 @@ def test_cond_update():
 @qpu
 def qpu_cond_combination(asm):
 
-    eidx(r0, sig = 'ldunif')
+    eidx(r0, sig = ldunif)
     mov(r2, r5)
     shl(r0, r0, 2)
     add(r2, r2, r0)
@@ -309,11 +309,11 @@ def qpu_cond_combination(asm):
     mov(tmua, r2)
     tmuwt(null).add(r2, r2, r1)
 
-    nop(null, sig = 'thrsw')
-    nop(null, sig = 'thrsw')
+    nop(null, sig = thrsw)
+    nop(null, sig = thrsw)
     nop(null)
     nop(null)
-    nop(null, sig = 'thrsw')
+    nop(null, sig = thrsw)
     nop(null)
     nop(null)
     nop(null)
@@ -353,7 +353,7 @@ def test_cond_combination():
 @qpu
 def qpu_cond_vflx(asm, ops):
 
-    eidx(r0, sig = 'ldunif')
+    eidx(r0, sig = ldunif)
     mov(r2, r5)
     shl(r0, r0, 2)
     add(r2, r2, r0)
@@ -373,11 +373,11 @@ def qpu_cond_vflx(asm, ops):
         mov(tmua, r2)
         tmuwt(null).add(r2, r2, r1)
 
-    nop(null, sig = 'thrsw')
-    nop(null, sig = 'thrsw')
+    nop(null, sig = thrsw)
+    nop(null, sig = thrsw)
     nop(null)
     nop(null)
-    nop(null, sig = 'thrsw')
+    nop(null, sig = thrsw)
     nop(null)
     nop(null)
     nop(null)
@@ -422,7 +422,7 @@ def test_cond_vflx():
 @qpu
 def qpu_cond_vflx(asm, ops):
 
-    eidx(r0, sig = 'ldunif')
+    eidx(r0, sig = ldunif)
     mov(r2, r5)
     shl(r0, r0, 2)
     add(r2, r2, r0)
@@ -442,11 +442,11 @@ def qpu_cond_vflx(asm, ops):
         mov(tmua, r2)
         tmuwt(null).add(r2, r2, r1)
 
-    nop(null, sig = 'thrsw')
-    nop(null, sig = 'thrsw')
+    nop(null, sig = thrsw)
+    nop(null, sig = thrsw)
     nop(null)
     nop(null)
-    nop(null, sig = 'thrsw')
+    nop(null, sig = thrsw)
     nop(null)
     nop(null)
     nop(null)
@@ -490,9 +490,9 @@ def test_cond_vflx():
 @qpu
 def qpu_cond_flx(asm, ops):
 
-    eidx(r0, sig = 'ldunif')
-    mov(rf0, r5, sig = 'ldunif') # in
-    mov(rf1, r5, sig = 'ldunif')  # out
+    eidx(r0, sig = ldunif)
+    mov(rf0, r5, sig = ldunif) # in
+    mov(rf1, r5, sig = ldunif)  # out
     shl(r3, 4, 4).mov(rf2, r5)
 
     shl(r0, r0, 2)
@@ -500,12 +500,12 @@ def qpu_cond_flx(asm, ops):
     add(rf1, rf1, r0)
     add(rf2, rf2, r0)
 
-    mov(tmua, rf0, sig = 'thrsw').add(rf0, rf0, r3)
+    mov(tmua, rf0, sig = thrsw).add(rf0, rf0, r3)
     nop(null)
-    mov(tmua, rf1, sig = 'thrsw').add(rf1, rf1, r3)
-    nop(r1, sig = 'ldtmu')
+    mov(tmua, rf1, sig = thrsw).add(rf1, rf1, r3)
+    nop(null, sig = ldtmu(r1))
     nop(null)
-    nop(r2, sig = 'ldtmu')
+    nop(null, sig = ldtmu(r2))
 
     # init fla/flb
     mov(null, r2, cond = 'pushn')
@@ -517,11 +517,11 @@ def qpu_cond_flx(asm, ops):
         mov(tmua, rf2)
         tmuwt(null).add(rf2, rf2, r3)
 
-    nop(null, sig = 'thrsw')
-    nop(null, sig = 'thrsw')
+    nop(null, sig = thrsw)
+    nop(null, sig = thrsw)
     nop(null)
     nop(null)
-    nop(null, sig = 'thrsw')
+    nop(null, sig = thrsw)
     nop(null)
     nop(null)
     nop(null)

--- a/tests/test_qpu.py
+++ b/tests/test_qpu.py
@@ -7,7 +7,7 @@ from videocore6.assembler import qpu
 @qpu
 def qpu_clock(asm):
 
-    nop(null, sig = 'ldunif')
+    nop(null, sig = ldunif)
 
     L.loop
     sub(r5, r5, 1, cond = 'pushn')
@@ -16,11 +16,11 @@ def qpu_clock(asm):
     nop(null)
     nop(null)
 
-    nop(null, sig = 'thrsw')
-    nop(null, sig = 'thrsw')
+    nop(null, sig = thrsw)
+    nop(null, sig = thrsw)
     nop(null)
     nop(null)
-    nop(null, sig = 'thrsw')
+    nop(null, sig = thrsw)
     nop(null)
     nop(null)
     nop(null)
@@ -49,8 +49,8 @@ def test_clock():
 @qpu
 def qpu_tmu_write(asm):
 
-    nop(null, sig = 'ldunif')
-    mov(r1, r5, sig = 'ldunif')
+    nop(null, sig = ldunif)
+    mov(r1, r5, sig = ldunif)
 
     # r2 = addr + eidx * 4
     # rf0 = eidx
@@ -73,11 +73,11 @@ def qpu_tmu_write(asm):
         shl(r0, 4, 4)
         tmuwt(null).add(r2, r2, r0)
 
-    nop(null, sig = 'thrsw')
-    nop(null, sig = 'thrsw')
+    nop(null, sig = thrsw)
+    nop(null, sig = thrsw)
     nop(null)
     nop(null)
-    nop(null, sig = 'thrsw')
+    nop(null, sig = thrsw)
     nop(null)
     nop(null)
     nop(null)
@@ -111,19 +111,19 @@ def qpu_tmu_read(asm):
     # r0: Number of vectors to read.
     # r1: Pointer to the read vectors + eidx * 4.
     # r2: Pointer to the write vectors + eidx * 4
-    eidx(r2, sig = 'ldunif')
-    mov(r0, r5, sig = 'ldunif')
+    eidx(r2, sig = ldunif)
+    mov(r0, r5, sig = ldunif)
     shl(r2, r2, 2).mov(r1, r5)
-    add(r1, r1, r2, sig = 'ldunif')
+    add(r1, r1, r2, sig = ldunif)
     add(r2, r5, r2)
 
     L.loop
     if True:
 
-        mov(tmua, r1, sig = 'thrsw')
+        mov(tmua, r1, sig = thrsw)
         nop(null)
         nop(null)
-        nop(rf0, sig = 'ldtmu')
+        nop(null, sig = ldtmu(rf0))
 
         sub(r0, r0, 1, cond = 'pushz').add(tmud, rf0, 1)
         b(R.loop, cond = 'anyna')
@@ -133,11 +133,11 @@ def qpu_tmu_read(asm):
         add(r1, r1, r3).add(r2, r2, r3)
         tmuwt(null)
 
-    nop(null, sig = 'thrsw')
-    nop(null, sig = 'thrsw')
+    nop(null, sig = thrsw)
+    nop(null, sig = thrsw)
     nop(null)
     nop(null)
-    nop(null, sig = 'thrsw')
+    nop(null, sig = thrsw)
     nop(null)
     nop(null)
     nop(null)

--- a/tests/test_sfu.py
+++ b/tests/test_sfu.py
@@ -26,18 +26,18 @@ ops = {
 @qpu
 def qpu_sfu_regs(asm, sfu_regs):
 
-    eidx(r0, sig = 'ldunif')
-    mov(rf0, r5, sig = 'ldunif') # in
+    eidx(r0, sig = ldunif)
+    mov(rf0, r5, sig = ldunif) # in
     shl(r3, 4, 4).mov(rf1, r5)
 
     shl(r0, r0, 2)
     add(rf0, rf0, r0)
     add(rf1, rf1, r0)
 
-    mov(tmua, rf0, sig = 'thrsw').add(rf0, rf0, r3)
+    mov(tmua, rf0, sig = thrsw).add(rf0, rf0, r3)
     nop(null)
     nop(null)
-    nop(r1, sig = 'ldtmu')
+    nop(null, sig = ldtmu(r1))
 
     g = globals()
     for reg in sfu_regs:
@@ -47,11 +47,11 @@ def qpu_sfu_regs(asm, sfu_regs):
         mov(tmua, rf1)
         tmuwt(null).add(rf1, rf1, r3)
 
-    nop(null, sig = 'thrsw')
-    nop(null, sig = 'thrsw')
+    nop(null, sig = thrsw)
+    nop(null, sig = thrsw)
     nop(null)
     nop(null)
-    nop(null, sig = 'thrsw')
+    nop(null, sig = thrsw)
     nop(null)
     nop(null)
     nop(null)
@@ -88,18 +88,18 @@ def test_sfu_regs():
 @qpu
 def qpu_sfu_ops(asm, sfu_ops):
 
-    eidx(r0, sig = 'ldunif')
-    mov(rf0, r5, sig = 'ldunif') # in
+    eidx(r0, sig = ldunif)
+    mov(rf0, r5, sig = ldunif) # in
     shl(r3, 4, 4).mov(rf1, r5)
 
     shl(r0, r0, 2)
     add(rf0, rf0, r0)
     add(rf1, rf1, r0)
 
-    mov(tmua, rf0, sig = 'thrsw').add(rf0, rf0, r3)
+    mov(tmua, rf0, sig = thrsw).add(rf0, rf0, r3)
     nop(null)
     nop(null)
-    nop(r1, sig = 'ldtmu')
+    nop(null, sig = ldtmu(r1))
 
     g = globals()
     for op in sfu_ops:
@@ -109,11 +109,11 @@ def qpu_sfu_ops(asm, sfu_ops):
         mov(tmua, rf1)
         tmuwt(null).add(rf1, rf1, r3)
 
-    nop(null, sig = 'thrsw')
-    nop(null, sig = 'thrsw')
+    nop(null, sig = thrsw)
+    nop(null, sig = thrsw)
     nop(null)
     nop(null)
-    nop(null, sig = 'thrsw')
+    nop(null, sig = thrsw)
     nop(null)
     nop(null)
     nop(null)

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -1,0 +1,64 @@
+
+import time
+from videocore6.driver import Driver
+from videocore6.assembler import qpu
+import numpy as np
+
+
+# ldtmu
+@qpu
+def qpu_signal_ldtmu(asm):
+
+    eidx(r0, sig = ldunif)
+    mov(rf0, r5, sig = ldunif)
+    shl(r3, 4, 4).mov(rf1, r5)
+
+    shl(r0, r0, 2)
+    add(rf0, rf0, r0)
+    add(rf1, rf1, r0)
+
+    mov(tmua, rf0, sig = thrsw).add(rf0, rf0, r3)        # start load X
+    mov(r0, 1.0)                                         # r0 <- 1.0
+    mov(r1, 2.0)                                         # r1 <- 2.0
+    fadd(r0, r0, r0).fmul(r1, r1, r1, sig = ldtmu(rf31)) # r0 <- 2 * r0, r1 <- r1 ^ 2, rf31 <- X
+    mov(tmud, rf31)
+    mov(tmua, rf1)
+    tmuwt(null).add(rf1, rf1, r3)
+    mov(tmud, r0)
+    mov(tmua, rf1)
+    tmuwt(null).add(rf1, rf1, r3)
+    mov(tmud, r1)
+    mov(tmua, rf1)
+    tmuwt(null).add(rf1, rf1, r3)
+
+    nop(null, sig = thrsw)
+    nop(null, sig = thrsw)
+    nop(null)
+    nop(null)
+    nop(null, sig = thrsw)
+    nop(null)
+    nop(null)
+    nop(null)
+
+def test_signal_ldtmu():
+
+    with Driver() as drv:
+
+        code = drv.program(qpu_signal_ldtmu)
+        X = drv.alloc((16, ), dtype = 'float32')
+        Y = drv.alloc((3, 16), dtype = 'float32')
+        unif = drv.alloc(3, dtype = 'uint32')
+
+        X[:] = np.random.randn(*X.shape).astype('float32')
+        Y[:] = 0.0
+
+        unif[0] = X.addresses()[0]
+        unif[1] = Y.addresses()[0,0]
+
+        start = time.time()
+        drv.execute(code, unif.addresses()[0])
+        end = time.time()
+
+        assert (Y[0] == X).all()
+        assert (Y[1] == 2).all()
+        assert (Y[2] == 4).all()

--- a/videocore6/assembler.py
+++ b/videocore6/assembler.py
@@ -118,7 +118,7 @@ class Signals(set):
             for sig in sigs:
                 self.add(sig)
         else:
-            raise AssembleError('Invalid signal instance')
+            raise AssembleError('Invalid signal object')
 
     def __int__(self):
         return {

--- a/videocore6/assembler.py
+++ b/videocore6/assembler.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 
 import struct
 import functools

--- a/videocore6/assembler.py
+++ b/videocore6/assembler.py
@@ -80,15 +80,17 @@ class Register(object):
         assert self.unpack_bits == Register.INPUT_MODIFIER['none']
         return Register(self.name, self.magic, self.waddr, unpack=modifier)
 
+
 class Signal(object):
 
-    def __init__(self, name, dst = None):
+    def __init__(self, name, dst=None):
         self.name = name
         self.dst = dst
 
     def is_write(self):
         ''' Write (to destinatino register) signal '''
         return self.dst is not None
+
 
 class WriteSignal(object):
 
@@ -97,6 +99,7 @@ class WriteSignal(object):
 
     def __call__(self, dst):
         return Signal(self.name, dst)
+
 
 class Signals(set):
 
@@ -158,6 +161,7 @@ class Signals(set):
         assert self.is_write()
         dst = [sig.dst for sig in self if sig.dst is not None][0]
         return (dst.magic << 6) | dst.waddr
+
 
 class Instruction(object):
 
@@ -827,7 +831,7 @@ def qpu(func):
             g[alias_op.__name__] = functools.partial(alias_op, asm)
         for waddr, reg in Instruction.REGISTERS.items():
             g[waddr] = reg
-        for name, sig  in Instruction.SIGNALS.items():
+        for name, sig in Instruction.SIGNALS.items():
             g[name] = sig
         func(asm, *args, **kwargs)
         g.clear()


### PR DESCRIPTION
load signals requires destination register as its argument.

Before this PR,
```python
fadd(r0, r0, r0).fmul(r1, r1, r1)
nop(r2, sig = 'ldtmu')
```

After this PR,
```python
fadd(r0, r0, r0).fmul(r1, r1, r1, sig = ldtmu(r2))
```