### PR TITLE
Integrate SFU register and operator

### DIFF
--- a/tests/test_sfu.py
+++ b/tests/test_sfu.py
@@ -11,13 +11,13 @@ def sfu_sin(x):
     return result
 
 ops = {
-    # sfu ops
-    'op_recip' : lambda x: 1 / x,
-    'op_rsqrt' : lambda x: 1 / np.sqrt(x),
-    'op_exp' : lambda x: 2 ** x,
-    'op_log' : np.log2,
-    'op_sin' : sfu_sin,
-    'op_rsqrt2' : lambda x: 1 / np.sqrt(x),
+    # sfu regs/ops
+    'recip' : lambda x: 1 / x,
+    'rsqrt' : lambda x: 1 / np.sqrt(x),
+    'exp' : lambda x: 2 ** x,
+    'log' : np.log2,
+    'sin' : sfu_sin,
+    'rsqrt2' : lambda x: 1 / np.sqrt(x),
 }
 
 
@@ -77,7 +77,7 @@ def boilerplate_sfu_regs(sfu_regs, domain_limitter):
 
         for ix, reg in enumerate(sfu_regs):
             msg = 'mov({}, None)'.format(reg)
-            assert np.allclose(Y[ix], ops['op_'+reg](X), rtol=1e-4), msg
+            assert np.allclose(Y[ix], ops[reg](X), rtol=1e-4), msg
 
 def test_sfu_regs():
     boilerplate_sfu_regs(['recip','exp','sin'], lambda x: x)
@@ -103,8 +103,7 @@ def qpu_sfu_ops(asm, sfu_ops):
 
     g = globals()
     for op in sfu_ops:
-        g['op_'+op](rf2, r1) # ATTENTION: SFU ops requires rfN ?
-        nop(null)
+        g[op](rf2, r1) # ATTENTION: SFU ops requires rfN ?
         mov(tmud, rf2)
         mov(tmua, rf1)
         tmuwt(null).add(rf1, rf1, r3)
@@ -139,7 +138,7 @@ def boilerplate_sfu_ops(sfu_ops, domain_limitter):
 
         for ix, op in enumerate(sfu_ops):
             msg = '{}(None, None)'.format(op)
-            assert np.allclose(Y[ix], ops['op_'+op](X), rtol=1e-4), msg
+            assert np.allclose(Y[ix], ops[op](X), rtol=1e-4), msg
 
 def test_sfu_ops():
     boilerplate_sfu_ops(['recip','exp','sin'], lambda x: x)

--- a/videocore6/assembler.py
+++ b/videocore6/assembler.py
@@ -106,12 +106,12 @@ class Instruction(object):
             'sync',
             'syncu',
             'syncb',
-            'recip',
-            'rsqrt',
-            'exp',
-            'log',
-            'sin',
-            'rsqrt2',
+            '_reg_recip',
+            '_reg_rsqrt',
+            '_reg_exp',
+            '_reg_log',
+            '_reg_sin',
+            '_reg_rsqrt2',
             '',
             '',
             '',
@@ -179,7 +179,7 @@ class Instruction(object):
         'flapush': 186,
         'flbpush': 186,
         'flpop': 186,
-        'op_recip': 186,
+        '_op_recip': 186,
         'setmsf': 186,
         'setrevf': 186,
 
@@ -199,11 +199,11 @@ class Instruction(object):
         'tmuwt': 187,
         'vpmwt': 187,
 
-        'op_rsqrt': 188,
-        'op_exp': 188,
-        'op_log': 188,
-        'op_sin': 188,
-        'op_rsqrt2': 188,
+        '_op_rsqrt': 188,
+        '_op_exp': 188,
+        '_op_log': 188,
+        '_op_sin': 188,
+        '_op_rsqrt2': 188,
 
         'fcmp': 192,
 
@@ -255,7 +255,7 @@ class Instruction(object):
         'flapush': 2,
         'flbpush': 3,
         'flpop': 4,
-        'op_recip': 5,
+        '_op_recip': 5,
         'setmsf': 6,
         'setrevf': 7,
 
@@ -287,11 +287,11 @@ class Instruction(object):
         'tmuwt': 2,
         'vpmwt': 2,
 
-        'op_rsqrt': 3,
-        'op_exp': 4,
-        'op_log': 5,
-        'op_sin': 6,
-        'op_rsqrt2': 7,
+        '_op_rsqrt': 3,
+        '_op_exp': 4,
+        '_op_log': 5,
+        '_op_sin': 6,
+        '_op_rsqrt2': 7,
 
         'itof': 0,
         'clz': 3,
@@ -742,6 +742,19 @@ _alias_ops = [
 ]
 
 
+class SFUIntegrator(Register):
+
+    def __init__(self, asm, name):
+        self.asm = asm
+        self.reg_name = '_reg_'+name
+        self.op_name = '_op_'+name
+        reg = Instruction.REGISTERS[self.reg_name]
+        super(SFUIntegrator, self).__init__(reg.name, reg.magic, reg.waddr)
+
+    def __call__(self, dst, src, **kwargs):
+        return Instruction(self.asm, self.op_name, dst, src, **kwargs)
+
+
 def qpu(func):
 
     @functools.wraps(func)
@@ -752,11 +765,15 @@ def qpu(func):
         g['R'] = Reference()
         g['b'] = functools.partial(Instruction, asm, 'b')
         for add_op in Instruction.add_ops.keys():
-            g[add_op] = functools.partial(Instruction, asm, add_op)
+            if not add_op.startswith('_op_'):
+                g[add_op] = functools.partial(Instruction, asm, add_op)
         for alias_op in _alias_ops:
             g[alias_op.__name__] = functools.partial(alias_op, asm)
         for waddr, reg in Instruction.REGISTERS.items():
-            g[waddr] = reg
+            if waddr.startswith('_reg_'):
+                g[waddr[5:]] = SFUIntegrator(asm, waddr[5:])
+            else:
+                g[waddr] = reg
         func(asm, *args, **kwargs)
         g.clear()
         for key, value in g_orig.items():


### PR DESCRIPTION
A SFU register is also treated as a corresponding SFU operator.
This PR removes `op_` which is prefixed to SFU operator to avoid a name conflict with SFU register.

Before this PR,

```python
mov(log, r0)
op_log(rf0, r0)
```

After this PR, 

```python
mov(log, r0)
log(rf0, r0)
```
