### PR TITLE
Handle rot signal

### DIFF
--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -313,7 +313,7 @@ def qpu_full_broadcast(asm):
     nop()
     nop()
     nop(sig = ldtmu(r0))
-    nop() # required before rotate ?
+    nop() # required before rotate
 
     for i in range(-15, 16):
         nop().mov(r5rep, r0, sig = [rot(ix) for ix in [i] if ix != 0] )
@@ -354,6 +354,63 @@ def test_full_broadcast():
             assert (Y[ix] == expected[(-rot%16)].repeat(16)).all()
 
 
+# broadcast alias
+@qpu
+def qpu_broadcast_alias(asm):
+
+    eidx(r0, sig = ldunif)
+    mov(rf0, r5, sig = ldunif)
+    shl(r3, 4, 4).mov(rf1, r5)
+
+    shl(r0, r0, 2)
+    add(rf0, rf0, r0)
+    add(rf1, rf1, r0)
+
+    mov(tmua, rf0, sig = thrsw).add(rf0, rf0, r3)
+    nop()
+    nop()
+    nop(sig = ldtmu(r0))
+    nop() # required before rotate
+
+    for i in range(-15, 16):
+        nop().mov(broadcast, r0, sig = [rot(ix) for ix in [i] if ix != 0] )
+        mov(tmud, r5)
+        mov(tmua, rf1)
+        tmuwt().add(rf1, rf1, r3)
+
+    nop(sig = thrsw)
+    nop(sig = thrsw)
+    nop()
+    nop()
+    nop(sig = thrsw)
+    nop()
+    nop()
+    nop()
+
+def test_broadcast_alias():
+
+    with Driver() as drv:
+
+        code = drv.program(qpu_broadcast_alias)
+        X = drv.alloc((16, ), dtype = 'int32')
+        Y = drv.alloc((len(range(-15, 16)), 16), dtype = 'int32')
+        unif = drv.alloc(3, dtype = 'uint32')
+
+        X[:] = np.arange(16)
+        Y[:] = 0
+
+        unif[0] = X.addresses()[0]
+        unif[1] = Y.addresses()[0,0]
+
+        start = time.time()
+        drv.execute(code, unif.addresses()[0])
+        end = time.time()
+
+        expected = X
+        for ix, rot in enumerate(range(-15, 16)):
+            assert (Y[ix] == expected[(-rot%16)].repeat(16)).all()
+
+
 # instruction with r5 dst performs as a quad broadcast
 @qpu
 def qpu_quad_broadcast(asm):
@@ -370,7 +427,7 @@ def qpu_quad_broadcast(asm):
     nop()
     nop()
     nop(sig = ldtmu(r0))
-    nop() # required before rotate ?
+    nop() # required before rotate
 
     for i in range(-15, 16):
         nop().mov(r5, r0, sig = [rot(ix) for ix in [i] if ix != 0] )
@@ -392,6 +449,63 @@ def test_quad_broadcast():
     with Driver() as drv:
 
         code = drv.program(qpu_quad_broadcast)
+        X = drv.alloc((16, ), dtype = 'int32')
+        Y = drv.alloc((len(range(-15, 16)), 16), dtype = 'int32')
+        unif = drv.alloc(3, dtype = 'uint32')
+
+        X[:] = np.arange(16)
+        Y[:] = 0
+
+        unif[0] = X.addresses()[0]
+        unif[1] = Y.addresses()[0,0]
+
+        start = time.time()
+        drv.execute(code, unif.addresses()[0])
+        end = time.time()
+
+        expected = np.concatenate([X,X])
+        for ix, rot in enumerate(range(-15, 16)):
+            assert (Y[ix] == expected[(-rot%16):(-rot%16)+16:4].repeat(4)).all()
+
+
+# instruction with r5 dst performs as a quad broadcast
+@qpu
+def qpu_quad_broadcast_alias(asm):
+
+    eidx(r0, sig = ldunif)
+    mov(rf0, r5, sig = ldunif)
+    shl(r3, 4, 4).mov(rf1, r5)
+
+    shl(r0, r0, 2)
+    add(rf0, rf0, r0)
+    add(rf1, rf1, r0)
+
+    mov(tmua, rf0, sig = thrsw).add(rf0, rf0, r3)
+    nop()
+    nop()
+    nop(sig = ldtmu(r0))
+    nop() # required before rotate
+
+    for i in range(-15, 16):
+        nop().mov(quad_broadcast, r0, sig = [rot(ix) for ix in [i] if ix != 0] )
+        mov(tmud, r5)
+        mov(tmua, rf1)
+        tmuwt().add(rf1, rf1, r3)
+
+    nop(sig = thrsw)
+    nop(sig = thrsw)
+    nop()
+    nop()
+    nop(sig = thrsw)
+    nop()
+    nop()
+    nop()
+
+def test_quad_broadcast_alias():
+
+    with Driver() as drv:
+
+        code = drv.program(qpu_quad_broadcast_alias)
         X = drv.alloc((16, ), dtype = 'int32')
         Y = drv.alloc((len(range(-15, 16)), 16), dtype = 'int32')
         unif = drv.alloc(3, dtype = 'uint32')

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -120,6 +120,66 @@ def test_full_rotate():
             assert (Y[ix] == expected[(-rot%16):(-rot%16)+16]).all()
 
 
+# rotate alias
+@qpu
+def qpu_rotate_alias(asm):
+
+    eidx(r0, sig = ldunif)
+    mov(rf0, r5, sig = ldunif)
+    shl(r3, 4, 4).mov(rf1, r5)
+
+    shl(r0, r0, 2)
+    add(rf0, rf0, r0)
+    add(rf1, rf1, r0)
+
+    mov(tmua, rf0, sig = thrsw).add(rf0, rf0, r3)
+    nop()
+    nop()
+    nop(sig = ldtmu(r0))
+    nop() # required before rotate
+
+    for i in range(-15, 16):
+        if i % 1 == 0:
+            rotate(r1, r0, i)       # add alias
+        else:
+            nop().rotate(r1, r0, i) # mul alias
+        mov(tmud, r1)
+        mov(tmua, rf1)
+        tmuwt().add(rf1, rf1, r3)
+
+    nop(sig = thrsw)
+    nop(sig = thrsw)
+    nop()
+    nop()
+    nop(sig = thrsw)
+    nop()
+    nop()
+    nop()
+
+def test_rotate_alias():
+
+    with Driver() as drv:
+
+        code = drv.program(qpu_rotate_alias)
+        X = drv.alloc((16, ), dtype = 'int32')
+        Y = drv.alloc((len(range(-15, 16)), 16), dtype = 'int32')
+        unif = drv.alloc(3, dtype = 'uint32')
+
+        X[:] = np.arange(16)
+        Y[:] = 0
+
+        unif[0] = X.addresses()[0]
+        unif[1] = Y.addresses()[0,0]
+
+        start = time.time()
+        drv.execute(code, unif.addresses()[0])
+        end = time.time()
+
+        expected = np.concatenate([X,X])
+        for ix, rot in enumerate(range(-15, 16)):
+            assert (Y[ix] == expected[(-rot%16):(-rot%16)+16]).all()
+
+
 # rot signal with rfN source performs as a quad rotate
 @qpu
 def qpu_quad_rotate(asm):

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -120,9 +120,9 @@ def test_full_rotate():
             assert (Y[ix] == expected[(-rot%16):(-rot%16)+16]).all()
 
 
-# rot signal with rfN source performs as a half rotate
+# rot signal with rfN source performs as a quad rotate
 @qpu
-def qpu_half_rotate(asm):
+def qpu_quad_rotate(asm):
 
     eidx(r0, sig = ldunif)
     mov(rf0, r5, sig = ldunif)
@@ -153,11 +153,11 @@ def qpu_half_rotate(asm):
     nop()
     nop()
 
-def test_half_rotate():
+def test_quad_rotate():
 
     with Driver() as drv:
 
-        code = drv.program(qpu_half_rotate)
+        code = drv.program(qpu_quad_rotate)
         X = drv.alloc((16, ), dtype = 'int32')
         Y = drv.alloc((len(range(-15, 16)), 16), dtype = 'int32')
         unif = drv.alloc(3, dtype = 'uint32')
@@ -177,9 +177,9 @@ def test_half_rotate():
             assert (Y[ix] == expected[:,(-rot%4):(-rot%4)+4].ravel()).all()
 
 
-# instruction with r5 dst performs as a half broadcast
+# instruction with r5 dst performs as a quad broadcast
 @qpu
-def qpu_half_broadcast(asm):
+def qpu_quad_broadcast(asm):
 
     eidx(r0, sig = ldunif)
     mov(rf0, r5, sig = ldunif)
@@ -210,11 +210,11 @@ def qpu_half_broadcast(asm):
     nop()
     nop()
 
-def test_half_broadcast():
+def test_quad_broadcast():
 
     with Driver() as drv:
 
-        code = drv.program(qpu_half_broadcast)
+        code = drv.program(qpu_quad_broadcast)
         X = drv.alloc((16, ), dtype = 'int32')
         Y = drv.alloc((len(range(-15, 16)), 16), dtype = 'int32')
         unif = drv.alloc(3, dtype = 'uint32')

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -177,6 +177,63 @@ def test_quad_rotate():
             assert (Y[ix] == expected[:,(-rot%4):(-rot%4)+4].ravel()).all()
 
 
+# instruction with r5rep dst performs as a full broadcast
+@qpu
+def qpu_full_broadcast(asm):
+
+    eidx(r0, sig = ldunif)
+    mov(rf0, r5, sig = ldunif)
+    shl(r3, 4, 4).mov(rf1, r5)
+
+    shl(r0, r0, 2)
+    add(rf0, rf0, r0)
+    add(rf1, rf1, r0)
+
+    mov(tmua, rf0, sig = thrsw).add(rf0, rf0, r3)
+    nop()
+    nop()
+    nop(sig = ldtmu(r0))
+    nop() # required before rotate ?
+
+    for i in range(-15, 16):
+        nop().mov(r5rep, r0, sig = [rot(ix) for ix in [i] if ix != 0] )
+        mov(tmud, r5)
+        mov(tmua, rf1)
+        tmuwt().add(rf1, rf1, r3)
+
+    nop(sig = thrsw)
+    nop(sig = thrsw)
+    nop()
+    nop()
+    nop(sig = thrsw)
+    nop()
+    nop()
+    nop()
+
+def test_full_broadcast():
+
+    with Driver() as drv:
+
+        code = drv.program(qpu_full_broadcast)
+        X = drv.alloc((16, ), dtype = 'int32')
+        Y = drv.alloc((len(range(-15, 16)), 16), dtype = 'int32')
+        unif = drv.alloc(3, dtype = 'uint32')
+
+        X[:] = np.arange(16)
+        Y[:] = 0
+
+        unif[0] = X.addresses()[0]
+        unif[1] = Y.addresses()[0,0]
+
+        start = time.time()
+        drv.execute(code, unif.addresses()[0])
+        end = time.time()
+
+        expected = X
+        for ix, rot in enumerate(range(-15, 16)):
+            assert (Y[ix] == expected[(-rot%16)].repeat(16)).all()
+
+
 # instruction with r5 dst performs as a quad broadcast
 @qpu
 def qpu_quad_broadcast(asm):

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -62,3 +62,59 @@ def test_signal_ldtmu():
         assert (Y[0] == X).all()
         assert (Y[1] == 2).all()
         assert (Y[2] == 4).all()
+
+# rot works for MulALU
+@qpu
+def qpu_signal_rot(asm):
+
+    eidx(r0, sig = ldunif)
+    mov(rf0, r5, sig = ldunif)
+    shl(r3, 4, 4).mov(rf1, r5)
+
+    shl(r0, r0, 2)
+    add(rf0, rf0, r0)
+    add(rf1, rf1, r0)
+
+    mov(tmua, rf0, sig = thrsw).add(rf0, rf0, r3)
+    nop()
+    nop()
+    nop(sig = ldtmu(r0))
+    nop() # required before rotate ?
+
+    for i in range(-15, 16):
+        nop().add(r1, r0, r0, sig = rot(i))
+        mov(tmud, r1)
+        mov(tmua, rf1)
+        tmuwt().add(rf1, rf1, r3)
+
+    nop(sig = thrsw)
+    nop(sig = thrsw)
+    nop()
+    nop()
+    nop(sig = thrsw)
+    nop()
+    nop()
+    nop()
+
+def test_signal_rot():
+
+    with Driver() as drv:
+
+        code = drv.program(qpu_signal_rot)
+        X = drv.alloc((16, ), dtype = 'int32')
+        Y = drv.alloc((len(range(-15, 16)), 16), dtype = 'int32')
+        unif = drv.alloc(3, dtype = 'uint32')
+
+        X[:] = np.arange(16)
+        Y[:] = 0
+
+        unif[0] = X.addresses()[0]
+        unif[1] = Y.addresses()[0,0]
+
+        start = time.time()
+        drv.execute(code, unif.addresses()[0])
+        end = time.time()
+
+        expected = np.concatenate([X,X]) * 2
+        for ix, rot in enumerate(range(-15, 16)):
+            assert (Y[ix] == expected[(-rot%16):(-rot%16)+16]).all()

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -79,7 +79,7 @@ def qpu_signal_rot(asm):
     nop()
     nop()
     nop(sig = ldtmu(r0))
-    nop() # required before rotate ?
+    nop() # required before rotate
 
     for i in range(-15, 16):
         nop().add(r1, r0, r0, sig = rot(i))
@@ -118,3 +118,60 @@ def test_signal_rot():
         expected = np.concatenate([X,X]) * 2
         for ix, rot in enumerate(range(-15, 16)):
             assert (Y[ix] == expected[(-rot%16):(-rot%16)+16]).all()
+
+
+# half broadcast example
+@qpu
+def qpu_half_broadcast(asm):
+
+    eidx(r0, sig = ldunif)
+    mov(rf0, r5, sig = ldunif)
+    shl(r3, 4, 4).mov(rf1, r5)
+
+    shl(r0, r0, 2)
+    add(rf0, rf0, r0)
+    add(rf1, rf1, r0)
+
+    mov(tmua, rf0, sig = thrsw).add(rf0, rf0, r3)
+    nop()
+    nop()
+    nop(sig = ldtmu(r0))
+    nop() # required before rotate ?
+
+    for i in range(-15, 16):
+        nop().mov(r5, r0, sig = [rot(ix) for ix in [i] if ix != 0] )
+        mov(tmud, r5)
+        mov(tmua, rf1)
+        tmuwt().add(rf1, rf1, r3)
+
+    nop(sig = thrsw)
+    nop(sig = thrsw)
+    nop()
+    nop()
+    nop(sig = thrsw)
+    nop()
+    nop()
+    nop()
+
+def test_half_broadcast():
+
+    with Driver() as drv:
+
+        code = drv.program(qpu_half_broadcast)
+        X = drv.alloc((16, ), dtype = 'int32')
+        Y = drv.alloc((len(range(-15, 16)), 16), dtype = 'int32')
+        unif = drv.alloc(3, dtype = 'uint32')
+
+        X[:] = np.arange(16)
+        Y[:] = 0
+
+        unif[0] = X.addresses()[0]
+        unif[1] = Y.addresses()[0,0]
+
+        start = time.time()
+        drv.execute(code, unif.addresses()[0])
+        end = time.time()
+
+        expected = np.concatenate([X,X])
+        for ix, rot in enumerate(range(-15, 16)):
+            assert (Y[ix] == expected[(-rot%16):(-rot%16)+16:4].repeat(4)).all()

--- a/videocore6/assembler.py
+++ b/videocore6/assembler.py
@@ -966,19 +966,40 @@ def _rotate_m(self, dst, src, rot, **kwargs):
         sigs.add(kwargs['sig'])
         del kwargs['sig']
     sigs.add(Instruction.SIGNALS['rot'](rot))
+    if not isinstance(src, Register) or src.magic != 1:
+        raise AssembleError('Invalid src object for rotate')
     return self.mov(dst, src, sig=sigs, **kwargs)
 
 
 ALU.rotate = _rotate_m
 
 
+def _quad_rotate_m(self, dst, src, rot, **kwargs):
+    sigs = Signals()
+    if 'sig' in kwargs:
+        sigs.add(kwargs['sig'])
+        del kwargs['sig']
+    sigs.add(Instruction.SIGNALS['rot'](rot))
+    if not isinstance(src, Register) or src.magic != 0:
+        raise AssembleError('Invalid src object for quad_rotate')
+    return self.mov(dst, src, sig=sigs, **kwargs)
+
+
+ALU.quad_rotate = _quad_rotate_m
+
+
 def _rotate_a(asm, *args, **kwargs):
     return ALU(asm, 'nop').rotate(*args, **kwargs)
+
+
+def _quad_rotate_a(asm, *args, **kwargs):
+    return ALU(asm, 'nop').quad_rotate(*args, **kwargs)
 
 
 _add_alias_ops = {
     'mov': _mov_a,
     'rotate': _rotate_a,
+    'quad_rotate': _quad_rotate_a,
 }
 
 

--- a/videocore6/assembler.py
+++ b/videocore6/assembler.py
@@ -879,6 +879,16 @@ class Branch(Instruction):
             | ((self.raddr_a if self.raddr_a is not None else 0) << 6)
 
 
+class Raw(Instruction):
+
+    def __init__(self, asm, packed_code):
+        super(Raw, self).__init__(asm)
+        self.packed_code = packed_code
+
+    def pack(self):
+        return self.packed_code
+
+
 class SFUIntegrator(Register):
 
     def __init__(self, asm, name):
@@ -910,6 +920,7 @@ def qpu(func):
         g['L'] = Label(asm)
         g['R'] = Reference(asm)
         g['b'] = functools.partial(Branch, asm, 'b')
+        g['raw'] = functools.partial(Raw, asm)
         for mul_op in MulALUOp.OPERATIONS.keys():
             g[mul_op] = functools.partial(ALU, asm, mul_op)
         for add_op in AddALUOp.OPERATIONS.keys():

--- a/videocore6/assembler.py
+++ b/videocore6/assembler.py
@@ -996,10 +996,15 @@ def _quad_rotate_a(asm, *args, **kwargs):
     return ALU(asm, 'nop').quad_rotate(*args, **kwargs)
 
 
-_add_alias_ops = {
+_alias_ops = {
     'mov': _mov_a,
     'rotate': _rotate_a,
     'quad_rotate': _quad_rotate_a,
+}
+
+_alias_regs = {
+    'broadcast': Instruction.REGISTERS['r5rep'],
+    'quad_broadcast': Instruction.REGISTERS['r5'],
 }
 
 
@@ -1023,8 +1028,10 @@ def qpu(func):
                 g[waddr[5:]] = SFUIntegrator(asm, waddr[5:])
             else:
                 g[waddr] = reg
-        for alias_name, alias_op in _add_alias_ops.items():
+        for alias_name, alias_op in _alias_ops.items():
             g[alias_name] = functools.partial(alias_op, asm)
+        for alias_name, alias_reg in _alias_regs.items():
+            g[alias_name] = alias_reg
         for name, sig in Instruction.SIGNALS.items():
             if name != 'smimm':  # smimm signal is automatically derived
                 g[name] = sig

--- a/videocore6/assembler.py
+++ b/videocore6/assembler.py
@@ -126,6 +126,8 @@ class Signals(set):
             sig = sigs
             if sig.name in [s.name for s in self]:
                 raise AssembleError(f'Signal "{sig}" is duplicated')
+            if sig.rot == 0:  # ignore rot(0)
+                return
             super(Signals, self).add(sig)
             if len([s.dst for s in self if s.dst is not None]) > 1:
                 raise AssembleError('Too many signals that require destination register')


### PR DESCRIPTION
Impl `rot` signal handling and its tests.

* full rotate (`rot` signal with `rN` source)
* quad rotate (`rot` signal with `rfN` source)
* full broadcast (`r5rep` destination)
* quad broadcast (`r5` destination)