### PR TITLE
Fix label creation bug which caused by namespace

### DIFF
--- a/tests/test_labels.py
+++ b/tests/test_labels.py
@@ -44,6 +44,15 @@ def qpu_label_with_namespace(asm):
     L.test
     add(r0, r0, 1)
 
+    with namespace('ns3'):
+        b(R.test, cond = 'always')
+        nop()
+        nop()
+        nop()
+        add(r0, r0, 10)
+        L.test
+        add(r0, r0, 1)
+
     eidx(r1, sig = ldunifrf(rf2))
     shl(r1, r1, 2)
 
@@ -76,4 +85,4 @@ def test_label_with_namespace():
         drv.execute(code, unif.addresses()[0])
         end = time.time()
 
-        assert (data == 4).all()
+        assert (data == 5).all()

--- a/videocore6/assembler.py
+++ b/videocore6/assembler.py
@@ -15,9 +15,9 @@ class Assembly(list):
         self.label_name_spaces = []
 
     def _gen_unused_label(self, label_format='{}'):
-        n = len(self.labels)
+        n = 0
         label = label_format.format(n)
-        while label in self.labels:
+        while self._gen_ns_label_name(label) in self.labels:
             n += 1
             next_label = label_format.format(n)
             assert label != next_label, 'Bug: Invalid label format'
@@ -51,19 +51,20 @@ class Label(object):
         self.asm = asm
 
     def __getattr__(self, name):
-        if name in self.asm.labels:
+        ns_name = self.asm._gen_ns_label_name(name)
+        if ns_name in self.asm.labels:
             raise AssembleError(f'Label is duplicated: {name}')
-        self.asm.labels[self.asm._gen_ns_label_name(name)] = len(self.asm)
+        self.asm.labels[ns_name] = len(self.asm)
 
 
 class Reference(object):
 
     def __init__(self, asm, name=None):
         self.asm = asm
-        self.name = name
+        self.name = self.asm._gen_ns_label_name(name) if name is not None else None
 
     def __getattr__(self, name):
-        return Reference(self.asm, self.asm._gen_ns_label_name(name))
+        return Reference(self.asm, name)
 
     def __int__(self):
         return self.asm.labels[self.name]


### PR DESCRIPTION
If a label named `foo` already created at top level, creating a new label `foo` under namespace is failed.

This PR fix this bug.