### PR TITLE
sgemm.py: Remove an extra load when the number of params is a multiple of 16

### DIFF
--- a/examples/sgemm.py
+++ b/examples/sgemm.py
@@ -50,10 +50,7 @@ def load_params(asm, thread, regs):
         if i % 16 == 0:
             mov(r5rep, r1)
             mov(regs[i], r5)
-        elif i - 1 == n:
-            rotate(r5rep, r1, - (i % 16))
-            mov(regs[i], r5)
-        elif i % 16 == 15:
+        elif i % 16 == 15 and i != n - 1:
             mov(tmua, r0, sig = thrsw).add(r0, r0, r3)
             rotate(r5rep, r1, - (i % 16))
             mov(regs[i], r5)


### PR DESCRIPTION
This is not so significant, but the condition for the case that the number of params is a multiple of 16 was wrong. This PR fixes that.

Assembler output for `n = 16` case before the fix:
```
or  tmua, r0, r0     ; add  r0, r0, r3   ; thrsw
nop                  ; nop
nop                  ; nop
nop                  ; nop               ; ldtmu.r1
or  r5rep, r1, r1    ; nop
or  rf32, r5, r5     ; nop
nop                  ; mov  r5rep, r1
or  rf33, r5, r5     ; nop

...

nop                  ; mov  r5rep, r1
or  rf46, r5, r5     ; nop
or  tmua, r0, r0     ; add  r0, r0, r3   ; thrsw
nop                  ; mov  r5rep, r1
or  rf47, r5, r5     ; nop
nop                  ; nop               ; ldtmu.r1
add  r0, rf32, 15    ; nop
```

The same case after the fix:
```
or  tmua, r0, r0     ; add  r0, r0, r3   ; thrsw
nop                  ; nop
nop                  ; nop
nop                  ; nop               ; ldtmu.r1
or  r5rep, r1, r1    ; nop
or  rf32, r5, r5     ; nop
nop                  ; mov  r5rep, r1
or  rf33, r5, r5     ; nop

...

nop                  ; mov  r5rep, r1
or  rf46, r5, r5     ; nop
nop                  ; mov  r5rep, r1
or  rf47, r5, r5     ; nop
add  r0, rf32, 15    ; nop
```