### PR TITLE
Support for V3D register access via /dev/mem

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,6 +6,10 @@ end_of_line = lf
 trim_trailing_whitespace = true
 insert_final_newline = true
 
-[*.{py,pyx}]
+[*.py]
+indent_style = space
+indent_size = 4
+
+[*.c]
 indent_style = space
 indent_size = 4

--- a/README.md
+++ b/README.md
@@ -59,12 +59,10 @@ $ sudo PYTHONPATH=dest nosetests -v -s
 
 ## Running examples
 
-After installing `py-videocore6`:
+In the `py-videocore6` directory:
 
 ```
-$ git clone https://github.com/Idein/py-videocore6.git
-$ cd py-videocore6/
-$ python3 examples/sgemm.py
+$ PYTHONPATH=. python3 examples/sgemm.py
 ==== sgemm example (123x567 times 567x512) ====
 numpy: 0.03433 sec, 2.086 Gflop/s
 QPU:   0.8327 sec, 0.08599 Gflop/s
@@ -76,3 +74,10 @@ Maximum relative error: 0.0
 
 Note that the current implementation of sgemm is seriously naive, and therefore
 the performance is low at least for now.
+
+```
+$ pip3 install --target dest .
+$ sudo PYTHONPATH=dest python3 examples/pctr_gpu_clock.py
+==== QPU clock measurement with performance counters ====
+500.535482 MHz
+```

--- a/README.md
+++ b/README.md
@@ -50,6 +50,13 @@ $ cd py-videocore6/
 $ nosetests -v -s
 ```
 
+To run all tests including the ones which require root privilege:
+
+```
+$ pip3 install --target dest . nose
+$ sudo PYTHONPATH=dest nosetests -v -s
+```
+
 ## Running examples
 
 After installing `py-videocore6`:

--- a/examples/pctr_gpu_clock.py
+++ b/examples/pctr_gpu_clock.py
@@ -1,0 +1,14 @@
+
+import time
+
+from videocore6.v3d import *
+
+with RegisterMapping() as regmap:
+
+    with PerformanceCounter(regmap, [CORE_PCTR_CYCLE_COUNT]) as pctr:
+
+        time.sleep(1)
+        result = pctr.result()
+
+print('==== QPU clock measurement with performance counters ====')
+print(f'{result[0] * 1e-6} MHz')

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 
-from setuptools import setup
+from setuptools import setup, Extension
+
 from videocore6 import __version__ as version
 
 
@@ -15,6 +16,14 @@ setup(
         install_requires = [
                 'ioctl-opt >= 1.2',
                 'numpy',
+        ],
+        ext_modules = [
+                Extension(
+                        'videocore6.readwrite4',
+                        sources = [
+                                'videocore6/readwrite4.c',
+                        ],
+                ),
         ],
         python_requires = '~= 3.7',  # for f-string.
 )

--- a/tests/test_v3d.py
+++ b/tests/test_v3d.py
@@ -1,0 +1,37 @@
+
+from videocore6.drm_v3d import DRM_V3D
+from videocore6.v3d import *
+
+
+def test_v3d_regs():
+
+    with DRM_V3D() as drm:
+
+        try:
+
+            with RegisterMapping() as regmap:
+
+                assert regmap[HUB_UIFCFG] \
+                        == drm.v3d_get_param(DRM_V3D.V3D_PARAM_V3D_UIFCFG)
+
+                assert regmap[HUB_IDENT1] \
+                        == drm.v3d_get_param(DRM_V3D.V3D_PARAM_V3D_HUB_IDENT1)
+
+                assert regmap[HUB_IDENT2] \
+                        == drm.v3d_get_param(DRM_V3D.V3D_PARAM_V3D_HUB_IDENT2)
+
+                assert regmap[HUB_IDENT3] \
+                        == drm.v3d_get_param(DRM_V3D.V3D_PARAM_V3D_HUB_IDENT3)
+
+                assert regmap[CORE_IDENT0, 0] \
+                        == drm.v3d_get_param(DRM_V3D.V3D_PARAM_V3D_CORE0_IDENT0)
+
+                assert regmap[CORE_IDENT1, 0] \
+                        == drm.v3d_get_param(DRM_V3D.V3D_PARAM_V3D_CORE0_IDENT1)
+
+                assert regmap[CORE_IDENT2, 0] \
+                        == drm.v3d_get_param(DRM_V3D.V3D_PARAM_V3D_CORE0_IDENT2)
+
+        except PermissionError:
+
+            print('Skipping tests because of a lack of root privilege')

--- a/videocore6/readwrite4.c
+++ b/videocore6/readwrite4.c
@@ -1,0 +1,36 @@
+#include <stdint.h>
+
+
+uint32_t read4(void * const addr)
+{
+    uint32_t value;
+
+    asm volatile (
+#if defined(__arm__)
+            "ldr %[value], [%[addr]]\n\t"
+#elif defined(__aarch64__)
+            "ldr %w[value], [%[addr]]\n\t"
+#endif
+            : [value] "=r" (value)
+            : [addr] "r" (addr)
+            : "memory"
+    );
+
+    return value;
+}
+
+
+void write4(void * const addr, const uint32_t value)
+{
+    asm volatile (
+#if defined(__arm__)
+            "str %[value], [%[addr]]\n\t"
+#elif defined(__aarch64__)
+            "str %w[value], [%[addr]]\n\t"
+#endif
+            :
+            : [value] "r" (value),
+              [addr] "r" (addr)
+            : "memory"
+    );
+}

--- a/videocore6/v3d.py
+++ b/videocore6/v3d.py
@@ -1,0 +1,257 @@
+
+from ctypes import cdll, c_uint32, c_void_p
+from importlib.machinery import EXTENSION_SUFFIXES
+from pathlib import Path
+import mmap
+import os
+
+import numpy as np
+
+
+class HubRegister:
+
+    def __init__(self, offset):
+
+        self.offset = offset
+
+
+class PerCoreRegister:
+
+    def __init__(self, offset):
+
+        self.offset = offset
+
+
+class HubField:
+
+    def __init__(self, register, high, low):
+
+        assert isinstance(register, HubRegister)
+        self.register = register
+        self.mask = ((1 << (high - low + 1)) - 1) << low
+        self.shift = low
+
+
+class PerCoreField:
+
+    def __init__(self, register, high, low):
+
+        assert isinstance(register, PerCoreRegister)
+        self.register = register
+        self.mask = ((1 << (high - low + 1)) - 1) << low
+        self.shift = low
+
+
+# V3D register definitions derived from linux/drivers/gpu/drm/v3d/v3d_regs.h
+
+HUB_AXICFG = HubRegister(0x00000)
+
+HUB_UIFCFG = HubRegister(0x00004)
+
+HUB_IDENT0 = HubRegister(0x00008)
+
+HUB_IDENT1 = HubRegister(0x0000c)
+HUB_IDENT1_WITH_MSO = HubField(HUB_IDENT1, 19, 19)
+HUB_IDENT1_WITH_TSY = HubField(HUB_IDENT1, 18, 18)
+HUB_IDENT1_WITH_TFU = HubField(HUB_IDENT1, 17, 17)
+HUB_IDENT1_WITH_L3C = HubField(HUB_IDENT1, 16, 16)
+HUB_IDENT1_NHOSTS = HubField(HUB_IDENT1, 15, 12)
+HUB_IDENT1_NCORES = HubField(HUB_IDENT1, 11, 8)
+HUB_IDENT1_REV = HubField(HUB_IDENT1, 7, 4)
+HUB_IDENT1_TVER = HubField(HUB_IDENT1, 3, 0)
+
+HUB_IDENT2 = HubRegister(0x00010)
+HUB_IDENT2_WITH_MMU = HubField(HUB_IDENT2, 8, 8)
+HUB_IDENT2_L3C_NKB = HubField(HUB_IDENT2, 7, 0)
+
+HUB_IDENT3 = HubRegister(0x00014)
+HUB_IDENT3_IPREV = HubField(HUB_IDENT3, 15, 8)
+HUB_IDENT3_IPIDX = HubField(HUB_IDENT3, 7, 0)
+
+HUB_TFU_CS = HubRegister(0x00400)
+
+
+CORE_IDENT0 = PerCoreRegister(0x00000)
+CORE_IDENT0_VER = PerCoreField(CORE_IDENT0, 31, 24)
+
+CORE_IDENT1 = PerCoreRegister(0x00004)
+CORE_IDENT1_VPM_SIZE = PerCoreField(CORE_IDENT1, 31, 28)
+CORE_IDENT1_NSEM = PerCoreField(CORE_IDENT1, 23, 16, )
+CORE_IDENT1_NTMU = PerCoreField(CORE_IDENT1, 15, 12)
+CORE_IDENT1_QUPS = PerCoreField(CORE_IDENT1, 11, 8)
+CORE_IDENT1_NSLC = PerCoreField(CORE_IDENT1, 7, 4)
+CORE_IDENT1_REV = PerCoreField(CORE_IDENT1, 3, 0)
+
+CORE_IDENT2 = PerCoreRegister(0x00008)
+CORE_IDENT2_BCG = PerCoreField(CORE_IDENT2, 28, 28)
+
+CORE_MISCCFG = PerCoreRegister(0x00018)
+CORE_MISCCFG_QRMAXCNT = PerCoreField(CORE_MISCCFG, 3, 1)
+CORE_MISCCFG_OVRTMUOUT = PerCoreField(CORE_MISCCFG, 0, 0)
+
+CORE_L2CACTL = PerCoreRegister(0x00020)
+CORE_L2CACTL_L2CCLR = PerCoreField(CORE_L2CACTL, 2, 2)
+CORE_L2CACTL_L2CDIS = PerCoreField(CORE_L2CACTL, 1, 1)
+CORE_L2CACTL_L2CENA = PerCoreField(CORE_L2CACTL, 0, 0)
+
+CORE_SLCACTL = PerCoreRegister(0x00024)
+CORE_SLCACTL_TVCCS = PerCoreField(CORE_SLCACTL, 27, 24)
+CORE_SLCACTL_TDCCS = PerCoreField(CORE_SLCACTL, 19, 16)
+CORE_SLCACTL_UCC = PerCoreField(CORE_SLCACTL, 11, 8)
+CORE_SLCACTL_ICC = PerCoreField(CORE_SLCACTL, 3, 0)
+
+CORE_PCTR_0_EN = PerCoreRegister(0x00650)
+CORE_PCTR_0_CLR = PerCoreRegister(0x00654)
+CORE_PCTR_0_OVERFLOW = PerCoreRegister(0x00658)
+
+g = globals()
+
+for i in range(0, 32, 4):
+    name = f'CORE_PCTR_0_SRC_{i}_{i+3}'
+    g[name] = PerCoreRegister(0x00660 + i)
+    g[name + f'_S{i+3}'] = PerCoreField(g[name], 30, 24)
+    g[name + f'_S{i+2}'] = PerCoreField(g[name], 22, 16)
+    g[name + f'_S{i+1}'] = PerCoreField(g[name], 14, 8)
+    g[name + f'_S{i+0}'] = PerCoreField(g[name], 6, 0)
+    g[f'CORE_PCTR_0_SRC_{i+3}'] = PerCoreField(g[name], 30, 24)
+    g[f'CORE_PCTR_0_SRC_{i+2}'] = PerCoreField(g[name], 22, 16)
+    g[f'CORE_PCTR_0_SRC_{i+1}'] = PerCoreField(g[name], 14, 8)
+    g[f'CORE_PCTR_0_SRC_{i+0}'] = PerCoreField(g[name], 6, 0)
+
+for i in range(32):
+    g[f'CORE_PCTR_0_PCTR{i}'] = PerCoreRegister(0x00680 + 4 * i)
+
+del g, i
+
+CORE_PCTR_CYCLE_COUNT = 32
+
+
+class RegisterMapping:
+
+    def __init__(self):
+
+        stem = Path(__file__).parent / 'readwrite4'
+        for suffix in EXTENSION_SUFFIXES:
+            try:
+                lib = cdll.LoadLibrary(stem.with_suffix(suffix))
+            except OSError:
+                continue
+            else:
+                break
+        else:
+            raise Exception('readwrite4 library is not found.'
+                            + ' Your installation seems to be broken.')
+
+        self.read4 = lib.read4
+        self.write4 = lib.write4
+        del stem, lib
+
+        self.read4.argtypes = [c_void_p]
+        self.read4.restype = c_uint32
+        self.write4.argtypes = [c_void_p, c_uint32]
+        self.write4.restype = None
+
+        fd = os.open('/dev/mem', os.O_RDWR)
+
+        # XXX: Should use bcm_host_get_peripheral_address for the base address
+        # on userland, and consult /proc/device-tree/__symbols__/v3d and then
+        # /proc/device-tree/v3dbus/v3d@7ec04000/{reg-names,reg} for the offsets
+        # in the future.
+
+        self.map_hub = mmap.mmap(offset=0xfec00000, length=0x4000, fileno=fd,
+                                 flags=mmap.MAP_SHARED,
+                                 prot=mmap.PROT_READ | mmap.PROT_WRITE)
+        self.ptr_hub = np.frombuffer(self.map_hub).ctypes.data
+
+        self.ncores = 1
+        self.map_cores = [None] * self.ncores
+        self.ptr_cores = [None] * self.ncores
+        for core in range(self.ncores):
+            self.map_cores[core] = mmap.mmap(offset=0xfec04000 + 0x4000 * core,
+                                             length=0x4000, fileno=fd,
+                                             flags=mmap.MAP_SHARED,
+                                             prot=mmap.PROT_READ | mmap.PROT_WRITE)
+            self.ptr_cores[core] = \
+                np.frombuffer(self.map_cores[core]).ctypes.data
+
+        os.close(fd)
+
+    def __enter__(self):
+
+        return self
+
+    def __exit__(self, type, value, traceback):
+
+        pass
+
+    def _get_ptr(self, key, core):
+
+        if isinstance(key, (HubField, PerCoreField)):
+            return self._get_ptr(key.register, core)
+        elif isinstance(key, HubRegister):
+            assert core is None
+            return self.ptr_hub + key.offset
+        elif isinstance(key, PerCoreRegister):
+            return self.ptr_cores[core] + key.offset
+
+    def __getitem__(self, key):
+
+        core = None
+        if isinstance(key, tuple):
+            key, core = key
+
+        v = self.read4(self._get_ptr(key, core))
+
+        if isinstance(key, (HubField, PerCoreField)):
+            v = (v & key.mask) >> key.shift
+
+        return v
+
+    def __setitem__(self, key, value):
+
+        core = None
+        if isinstance(key, tuple):
+            key, core = key
+
+        if isinstance(key, (HubField, PerCoreField)):
+            value = (self[key.register, core] & ~key.mask) \
+                | ((value << key.shift) & key.mask)
+
+        self.write4(self._get_ptr(key, core), value)
+
+
+class PerformanceCounter:
+
+    _PCTR_SRCs = [globals()[f'CORE_PCTR_0_SRC_{_}'] for _ in range(32)]
+    _PCTRs = [globals()[f'CORE_PCTR_0_PCTR{_}'] for _ in range(32)]
+
+    def __init__(self, regmap, srcs):
+
+        self.regmap = regmap
+        self.srcs = srcs
+        self.core = 0  # Sufficient for now.
+        self.mask = (1 << len(self.srcs)) - 1
+
+    def __enter__(self):
+
+        self.regmap[CORE_PCTR_0_EN, self.core] = 0
+
+        for i in range(len(self.srcs)):
+            self.regmap[self._PCTR_SRCs[i], self.core] = self.srcs[i]
+
+        self.regmap[CORE_PCTR_0_CLR, self.core] = self.mask
+        self.regmap[CORE_PCTR_0_OVERFLOW, self.core] = self.mask
+        self.regmap[CORE_PCTR_0_EN, self.core] = self.mask
+
+        return self
+
+    def __exit__(self, type, value, traceback):
+
+        self.regmap[CORE_PCTR_0_EN, self.core] = 0
+        self.regmap[CORE_PCTR_0_CLR, self.core] = self.mask
+        self.regmap[CORE_PCTR_0_OVERFLOW, self.core] = self.mask
+
+    def result(self):
+
+        return [self.regmap[self._PCTRs[i], self.core]
+                for i in range(len(self.srcs))]


### PR DESCRIPTION
These commits add the functionality of accessing V3D registers via /dev/mem. The register definitions are derived from https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/tree/drivers/gpu/drm/v3d/v3d_regs.h but not all.

This enables the use of performance counters, though which source represents what metric is not known except for cycle count (32), which counts up every cycle. An example program that measures the QPU frequency is also added by using the counter.