### PR TITLE
Add dump_code to dump assembled program

### DIFF
--- a/videocore6/driver.py
+++ b/videocore6/driver.py
@@ -188,10 +188,12 @@ class Driver(object):
 
         return arr
 
-    def dump_program(self, prog, *args, **kwargs):
-        file = kwargs.pop('file') if 'file' in kwargs else sys.stdout
-        for insn in assemble(prog, *args, **kwargs):
+    def dump_code(self, code, *, file=sys.stdout):
+        for insn in code:
             print(f'{insn:#018x}', file=file)
+
+    def dump_program(self, prog, *args, file=sys.stdout, **kwargs):
+        self.dump_code(assemble(prog, *args, **kwargs), file=file)
 
     def program(self, prog, *args, **kwargs):
 


### PR DESCRIPTION
Before this change, we had to assemble a QPU program again to dump even if it is already assembled, which is inconvenient with many and complex arguments:

```python3
@qpu
def qpu_program(asm, arg1, arg2, arg3):
    ...

with Driver() as drv:
    code = drv.program(qpu_program, lots_of_calc1, lots_of_calc2, lots_of_calc3)
    drv.dump_program(qpu_program, lots_of_calc1, lots_of_calc2, lots_of_calc3)
    ...
```

After the change, we need to assemble the program only once:

```python3
with Driver() as drv:
    code = drv.program(qpu_program, lots_of_calc1, lots_of_calc2, lots_of_calc3)
    drv.dump_code(code)
    ...
```