### PR TITLE
videocore6: Add pack_unpack utility function

### DIFF
--- a/examples/sgemm.py
+++ b/examples/sgemm.py
@@ -1,15 +1,11 @@
 #!/usr/bin/env python3
 
 
-import struct
 from time import clock_gettime, CLOCK_MONOTONIC
 import numpy as np
+from videocore6 import pack_unpack
 from videocore6.driver import Driver
 from videocore6.assembler import qpu
-
-
-def pack_unpack(pack, unpack, *args):
-    return [struct.unpack(unpack, struct.pack(pack, _))[0] for _ in args]
 
 
 def getsec():
@@ -237,7 +233,7 @@ def sgemm_rnn_naive():
                 B.strides[0],
                 C.addresses()[tile_P*i, tile_R*j],
                 C.strides[0],
-                *pack_unpack('f', 'I', alpha, beta),
+                *pack_unpack('f', 'I', [alpha, beta]),
             ]
 
         unif_params = drv.alloc((thread, len(block_2x4_params(0,0))), dtype = 'uint32')

--- a/videocore6/__init__.py
+++ b/videocore6/__init__.py
@@ -1,16 +1,13 @@
 
 __version__ = '0.0.0'
 
+
 import struct
 
 
-def float_to_int(f):
-    return struct.unpack('i', struct.pack('f', f))[0]
+def pack_unpack(pack, unpack, v):
 
+    if isinstance(v, list):
+        return [struct.unpack(unpack, struct.pack(pack, _))[0] for _ in v]
 
-def int_to_float(i):
-    return struct.unpack('f', struct.pack('i', i))[0]
-
-
-def int_to_uint(i):
-    return struct.unpack('I', struct.pack('i', i))[0]
+    return struct.unpack(unpack, struct.pack(pack, v))[0]

--- a/videocore6/assembler.py
+++ b/videocore6/assembler.py
@@ -1,6 +1,6 @@
 
 import functools
-from videocore6 import float_to_int, int_to_float, int_to_uint
+from videocore6 import pack_unpack
 
 
 class AssembleError(Exception):
@@ -514,14 +514,15 @@ class ALURaddrs(object):
             for i in range(16):
                 smimms_int[i] = i
                 smimms_int[i - 16] = i + 16
-                smimms_int[float_to_int(2 ** (i - 8))] = i + 32
+                smimms_int[pack_unpack('i', 'I', i - 16)] = i + 16
+                smimms_int[pack_unpack('f', 'I', 2 ** (i - 8))] = i + 32
             return smimms_int[x]
 
         def pack_smimms_float(x):
             smimms_float = {}
             for i in range(16):
                 # Denormal numbers
-                smimms_float[int_to_float(i)] = i
+                smimms_float[pack_unpack('I', 'f', i)] = i
                 smimms_float[2 ** (i - 8)] = i + 32
             return smimms_float[x]
 
@@ -993,7 +994,8 @@ class Branch(Instruction):
     def pack(self):
 
         if self.addr_label is not None:
-            addr = int_to_uint((int(self.addr_label) - self.serial - 4) * 8)
+            addr = pack_unpack('i', 'I',
+                               (int(self.addr_label) - self.serial - 4) * 8)
         elif self.addr is not None:
             addr = self.addr
         else:


### PR DESCRIPTION
The former type conversion methods (int_to_float etc.) had ambiguous names. This commit introduces an alternative one named pack_unpack.