### PR TITLE
setup.py: Build readwrite4 only on ARMv7 platforms

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,16 @@
 
+import platform
+
 from setuptools import setup, Extension
 
 from videocore6 import __version__ as version
 
+
+ext_modules = []
+
+if platform.machine() == 'armv7l':
+    ext_modules.append(Extension('videocore6.readwrite4',
+                                 sources = ['videocore6/readwrite4.c']))
 
 setup(
         name = 'py-videocore6',
@@ -17,13 +25,6 @@ setup(
                 'ioctl-opt >= 1.2',
                 'numpy',
         ],
-        ext_modules = [
-                Extension(
-                        'videocore6.readwrite4',
-                        sources = [
-                                'videocore6/readwrite4.c',
-                        ],
-                ),
-        ],
+        ext_modules = ext_modules,
         python_requires = '~= 3.7',  # for f-string.
 )


### PR DESCRIPTION
Suggested by @notogawa.

This enables assembling on non-ARM platforms.