### PR TITLE
v3d: Support for AArch64 platform

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from videocore6 import __version__ as version
 
 ext_modules = []
 
-if platform.machine() == 'armv7l':
+if platform.machine() in ['armv7l', 'aarch64']:
     ext_modules.append(Extension('videocore6.readwrite4',
                                  sources = ['videocore6/readwrite4.c']))
 

--- a/tests/test_alu.py
+++ b/tests/test_alu.py
@@ -135,8 +135,8 @@ def boilerplate_binary_ops(bin_ops, dst, src1, src2):
         unif = drv.alloc(3, dtype = 'uint32')
 
         if np.dtype(dst_dtype).name.startswith('float'):
-            X1[:] = np.random.randn(*X1.shape).astype(src1_dtype)
-            X2[:] = np.random.randn(*X2.shape).astype(src2_dtype)
+            X1[:] = np.random.uniform(-(2**7), 2**7, X1.shape).astype(src1_dtype)
+            X2[:] = np.random.uniform(-(2**7), 2**7, X2.shape).astype(src2_dtype)
         elif np.dtype(dst_dtype).name.startswith('int'):
             X1[:] = np.random.randint(-(2**31), 2**31, X1.shape, dtype=src1_dtype)
             X2[:] = np.random.randint(-(2**31), 2**31, X2.shape, dtype=src2_dtype)
@@ -249,7 +249,7 @@ def boilerplate_unary_ops(uni_ops, dst, src):
         Y = drv.alloc((len(cases), 16*4//np.dtype(dst_dtype).itemsize), dtype = dst_dtype)
         unif = drv.alloc(3, dtype = 'uint32')
 
-        X[:] = np.random.randn(*X.shape).astype(src_dtype)
+        X[:] = np.random.uniform(-(2**15), 2**15, X.shape).astype(src_dtype)
         Y[:] = 0.0
 
         unif[0] = X.addresses()[0]

--- a/tests/test_alu.py
+++ b/tests/test_alu.py
@@ -134,8 +134,15 @@ def boilerplate_binary_ops(bin_ops, dst, src1, src2):
         Y = drv.alloc((len(cases), 16*4//np.dtype(dst_dtype).itemsize), dtype = dst_dtype)
         unif = drv.alloc(3, dtype = 'uint32')
 
-        X1[:] = np.random.randn(*X1.shape).astype(src1_dtype)
-        X2[:] = np.random.randn(*X2.shape).astype(src2_dtype)
+        if np.dtype(dst_dtype).name.startswith('float'):
+            X1[:] = np.random.randn(*X1.shape).astype(src1_dtype)
+            X2[:] = np.random.randn(*X2.shape).astype(src2_dtype)
+        elif np.dtype(dst_dtype).name.startswith('int'):
+            X1[:] = np.random.randint(-(2**31), 2**31, X1.shape, dtype=src1_dtype)
+            X2[:] = np.random.randint(-(2**31), 2**31, X2.shape, dtype=src2_dtype)
+        elif np.dtype(dst_dtype).name.startswith('uint'):
+            X1[:] = np.random.randint(0, 2**32, X1.shape, dtype=src1_dtype)
+            X2[:] = np.random.randint(0, 2**32, X2.shape, dtype=src2_dtype)
         Y[:] = 0.0
 
         unif[0] = X1.addresses()[0]

--- a/tests/test_alu.py
+++ b/tests/test_alu.py
@@ -37,10 +37,10 @@ ops = {
     'umin' : np.minimum,
     'umax' : np.maximum,
 
-    'shl' : lambda a,b: a << b,
-    'shr' : lambda a,b: a >> b,
-    'asr' : lambda a,b: a.astype('int32') >> b,
-    'ror' : np.vectorize(rotate_right),
+    'shl' : lambda a,b: a << (b % 32),
+    'shr' : lambda a,b: a >> (b % 32),
+    'asr' : lambda a,b: a.astype(np.int32) >> (b % 32),
+    'ror' : lambda a,b: np.vectorize(rotate_right)(a, b % 32),
 
     'band' : lambda a,b: a & b,
     'bor' : lambda a,b: a | b,
@@ -54,16 +54,16 @@ ops = {
     'fceil' : np.ceil,
     'fdx' : lambda x: (x[1::2] - x[0::2]).repeat(2),
     'fdy' : lambda x: (lambda a: (a[1::2] - a[0::2]).ravel())(x.reshape(-1,2).repeat(2,axis=0).reshape(-1,4)),
-    'ftoin': lambda x: x.round().astype('int32'),
-    'ftoiz': lambda x: np.trunc(x).astype('int32'),
-    'ftouz': lambda x: np.trunc(x).astype('uint32'),
+    'ftoin': lambda x: x.round().astype(np.int32),
+    'ftoiz': lambda x: np.float32(x).astype(np.int32),
+    'ftouz': np.vectorize(lambda x: np.float32(x).astype(np.uint32) if x > -1 else 0),
 
     'bnot' : lambda x: ~x,
     'neg' : lambda x: -x,
 
-    'itof' : lambda x: x.astype('float32'),
+    'itof' : lambda x: x.astype(np.float32),
     'clz' : np.vectorize(count_leading_zeros),
-    'utof' : lambda x: x.astype('float32'),
+    'utof' : lambda x: x.astype(np.float32),
 
     # pack/unpack flags
     'l' : lambda x: x[0::2],
@@ -177,7 +177,7 @@ def test_binary_ops():
         )
 
     boilerplate_binary_ops(
-        ['add', 'sub', 'imin', 'imax'],
+        ['add', 'sub', 'imin', 'imax', 'asr'],
         ('int32', [None]), ('int32', [None]), ('int32', [None]),
     )
     boilerplate_binary_ops(
@@ -185,7 +185,7 @@ def test_binary_ops():
         ('uint32', [None]), ('uint32', [None]), ('uint32', [None]),
     )
     boilerplate_binary_ops(
-        ['shl', 'shr', 'asr', 'ror'],
+        ['shl', 'shr', 'ror'],
         ('uint32', [None]), ('uint32', [None]), ('uint32', [None]),
     )
     boilerplate_binary_ops(

--- a/videocore6/readwrite4.c
+++ b/videocore6/readwrite4.c
@@ -1,3 +1,11 @@
+
+#if defined(__arm__) && defined(__aarch64__)
+#error "__arm__ and __aarch64__ are both defined"
+#elif !defined(__arm__) && !defined(__aarch64__)
+#error "__arm__ and __aarch64__ are both not defined"
+#endif
+
+
 #include <stdint.h>
 
 


### PR DESCRIPTION
The previous setup code only supports armv7l platforms. This PR enables us to access the V3D on AArch64 kernel. I tested this on Raspberry Pi 4 Model B with:

Distribution and kernel | `platform.machine()` | `sys.maxsize`
-- | -- | --
Raspbian (armhf) with kernelv7l.img | armv7l | < 2^31
Raspbian (armhf) with kernel8.img | aarch64 | < 2^31
Gentoo (arm64) with kernel8.img | aarch64 | > 2^31

Note that, on the second entry, armv7l 32-bit binary is produced and executed because the userland is 32-bit, which conflicts with `platform.machine()` (aarch64). This is not a problem for now because [the current code](https://github.com/Idein/py-videocore6/blob/master/videocore6/v3d.py#L134) finds the binary of current bit size of the userland, but be careful when you play with that.