### PR TITLE
More three simple examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ If you choose the former, run `sudo usermod --append --groups video $USER`
 
 You can install `py-videocore6` directly using `pip`:
 
-```
+```console
 $ sudo apt update
 $ sudo apt upgrade
 $ sudo apt install python3-pip python3-numpy
@@ -47,7 +47,7 @@ $ pip3 install --user git+https://github.com/Idein/py-videocore6.git
 If you are willing to run tests and examples, install `py-videocore6` after
 cloning it:
 
-```
+```console
 $ sudo apt update
 $ sudo apt upgrade
 $ sudo apt install python3-pip python3-numpy libatlas3-base
@@ -62,12 +62,12 @@ $ python3 -m pip install --target sandbox/ --upgrade . nose
 
 In the `py-videocore6` directory cloned above:
 
-```
+```console
 $ python3 setup.py build_ext --inplace
 $ PYTHONPATH=sandbox/ python3 -m nose -v -s
 ```
 
-```
+```console
 $ PYTHONPATH=sandbox/ python3 examples/sgemm.py
 ==== sgemm example (1024x1024 times 1024x1024) ====
 numpy: 0.6986 sec, 3.078 Gflop/s
@@ -78,7 +78,7 @@ Minimum relative error: 0.0
 Maximum relative error: 0.13375753164291382
 ```
 
-```
+```console
 $ sudo PYTHONPATH=sandbox/ python3 examples/pctr_gpu_clock.py
 ==== QPU clock measurement with performance counters ====
 500.529835 MHz

--- a/README.md
+++ b/README.md
@@ -79,6 +79,30 @@ Maximum relative error: 0.13375753164291382
 ```
 
 ```console
+$ PYTHONPATH=sandbox/ python3 examples/summation.py
+==== summaton example (32.0 Mi elements) ====
+Preparing for buffers...
+Executing on QPU...
+0.01914575099999638 sec, 7010.314090057129 MB/s
+```
+
+```console
+$ PYTHONPATH=sandbox/ python3 examples/memset.py
+==== memset example (64.0 MiB) ====
+Preparing for buffers...
+Executing on QPU...
+0.017949476000467257 sec, 3738.76451871091 MB/s
+```
+
+```console
+$ PYTHONPATH=sandbox/ python3 examples/scopy.py
+==== scopy example (16.0 Mi elements) ====
+Preparing for buffers...
+Executing on QPU...
+0.028124778999881528 sec, 2386.1116917677 MB/s
+```
+
+```console
 $ sudo PYTHONPATH=sandbox/ python3 examples/pctr_gpu_clock.py
 ==== QPU clock measurement with performance counters ====
 500.529835 MHz

--- a/examples/memset.py
+++ b/examples/memset.py
@@ -1,0 +1,135 @@
+
+from time import monotonic
+
+import numpy as np
+
+from videocore6.assembler import qpu
+from videocore6.driver import Driver
+
+
+@qpu
+def qpu_memset(asm, *, num_qpus, unroll_shift, code_offset,
+               align_cond=lambda pos: pos % 512 == 0):
+
+    g = globals()
+    for i, v in enumerate(['dst', 'fill', 'length', 'qpu_num', 'stride']):
+        g[f'reg_{v}'] = rf[i]
+
+    nop(sig=ldunifrf(reg_dst))
+    nop(sig=ldunifrf(reg_fill))
+    nop(sig=ldunifrf(reg_length))
+
+    if num_qpus == 1:
+        num_qpus_shift = 0
+        mov(reg_qpu_num, 0)
+    elif num_qpus == 8:
+        num_qpus_shift = 3
+        tidx(r0)
+        shr(r0, r0, 2)
+        band(reg_qpu_num, r0, 0b1111)
+    else:
+        raise Exception('num_qpus must be 1 or 8')
+
+    # addr += 4 * (thread_num + 16 * qpu_num)
+    shl(r0, reg_qpu_num, 4)
+    eidx(r1)
+    add(r0, r0, r1)
+    shl(r0, r0, 2)
+    add(reg_dst, reg_dst, r0)
+
+    # stride = 4 * 16 * num_qpus
+    # r0 = 1
+    mov(r0, 1)
+    shl(reg_stride, r0, 6 + num_qpus_shift)
+
+    # length /= 16 * num_qpus * unroll
+    shr(reg_length, reg_length, 4 + num_qpus_shift + unroll_shift)
+
+    unroll = 1 << unroll_shift
+
+    if unroll == 1:
+
+        sub(reg_length, reg_length, r0, cond='pushz')
+
+        while not align_cond(code_offset + len(asm)):
+            nop()
+
+        with loop as l:
+
+            l.b(cond='na0')
+            mov(tmud, reg_fill)                                   # delay slot
+            mov(tmua, reg_dst).add(reg_dst, reg_dst, reg_stride)  # delay slot
+            sub(reg_length, reg_length, r0, cond='pushz')         # delay slot
+
+    else:
+
+        while not align_cond(code_offset + len(asm)):
+            nop()
+
+        with loop as l:
+
+            for i in range(unroll - 2):
+                mov(tmud, reg_fill)
+                mov(tmua, reg_dst).add(reg_dst, reg_dst, reg_stride)
+
+            mov(tmud, reg_fill).sub(reg_length, reg_length, r0, cond='pushz')
+            l.b(cond='na0')
+            mov(tmua, reg_dst).add(reg_dst, reg_dst, reg_stride)  # delay slot
+            mov(tmud, reg_fill)                                   # delay slot
+            mov(tmua, reg_dst).add(reg_dst, reg_dst, reg_stride)  # delay slot
+
+    nop(sig=thrsw)
+    nop(sig=thrsw)
+    nop()
+    nop()
+    nop(sig=thrsw)
+    nop()
+    nop()
+    nop()
+
+
+def memset(*, fill, length, num_qpus=8, unroll_shift=1):
+
+    assert length > 0
+    assert length % (16 * num_qpus * (1 << unroll_shift)) == 0
+
+    print(f'==== memset example ({length * 4 / 1024 / 1024} MiB) ====')
+
+    with Driver(data_area_size=(length + 1024) * 4) as drv:
+
+        code = drv.program(qpu_memset, num_qpus=num_qpus,
+                           unroll_shift=unroll_shift,
+                           code_offset=drv.code_pos // 8)
+
+        print('Preparing for buffers...')
+
+        X = drv.alloc(length, dtype='uint32')
+
+        X.fill(~fill)
+
+        assert not np.array_equiv(X, fill)
+
+        unif = drv.alloc(3, dtype='uint32')
+        unif[0] = X.addresses()[0]
+        unif[1] = fill
+        unif[2] = length
+
+        print('Executing on QPU...')
+
+        start = monotonic()
+        drv.execute(code, unif.addresses()[0], thread=num_qpus)
+        end = monotonic()
+
+        assert np.array_equiv(X, fill)
+
+        print(f'{end - start} sec, {length * 4 / (end - start) * 1e-6} MB/s')
+
+
+def main():
+
+    memset(fill=0x5a5a5a5a, length=16 * 1024 * 1024)
+
+
+if __name__ == '__main__':
+
+    main()

--- a/examples/scopy.py
+++ b/examples/scopy.py
@@ -1,0 +1,148 @@
+
+from time import monotonic
+
+import numpy as np
+
+from videocore6.assembler import qpu
+from videocore6.driver import Driver
+
+
+@qpu
+def qpu_scopy(asm, *, num_qpus, unroll_shift, code_offset,
+              align_cond=lambda pos: pos % 512 == 259):
+
+    g = globals()
+    for i, v in enumerate(['length', 'src', 'dst', 'qpu_num', 'stride']):
+        g[f'reg_{v}'] = rf[i]
+
+    nop(sig=ldunifrf(reg_length))
+    nop(sig=ldunifrf(reg_src))
+    nop(sig=ldunifrf(reg_dst))
+
+    if num_qpus == 1:
+        num_qpus_shift = 0
+        mov(reg_qpu_num, 0)
+    elif num_qpus == 8:
+        num_qpus_shift = 3
+        tidx(r0)
+        shr(r0, r0, 2)
+        band(reg_qpu_num, r0, 0b1111)
+    else:
+        raise Exception('num_qpus must be 1 or 8')
+
+    # addr += 4 * (thread_num + 16 * qpu_num)
+    shl(r0, reg_qpu_num, 4)
+    eidx(r1)
+    add(r0, r0, r1)
+    shl(r0, r0, 2)
+    add(reg_src, reg_src, r0).add(reg_dst, reg_dst, r0)
+
+    # stride = 4 * 16 * num_qpus
+    mov(reg_stride, 1)
+    shl(reg_stride, reg_stride, 6 + num_qpus_shift)
+
+    # length /= 16 * 8 * num_qpus * unroll
+    shr(reg_length, reg_length, 7 + num_qpus_shift + unroll_shift)
+
+    # This single thread switch and two nops just before the loop are really
+    # important for TMU read to achieve a better performance.
+    # This also enables TMU read requests without the thread switch signal, and
+    # the eight-depth TMU read request queue.
+    nop(sig=thrsw)
+    nop()
+    nop()
+
+    while not align_cond(code_offset + len(asm)):
+        nop()
+
+    with loop as l:
+
+        unroll = 1 << unroll_shift
+
+        for i in range(8):
+            mov(tmua, reg_src).add(reg_src, reg_src, reg_stride)
+
+        for j in range(unroll - 1):
+            for i in range(8):
+                nop(sig=ldtmu(r0))
+                mov(tmua, reg_src).add(reg_src, reg_src, reg_stride)
+                mov(tmud, r0)
+                mov(tmua, reg_dst).add(reg_dst, reg_dst, reg_stride)
+
+        for i in range(6):
+            nop(sig=ldtmu(r0))
+            mov(tmud, r0)
+            mov(tmua, reg_dst).add(reg_dst, reg_dst, reg_stride)
+
+        nop(sig=ldtmu(r0))
+        mov(tmud, r0).sub(reg_length, reg_length, 1, cond='pushz')
+        mov(tmua, reg_dst).add(reg_dst, reg_dst, reg_stride)
+
+        l.b(cond='na0')
+        nop(sig=ldtmu(r0))                                    # delay slot
+        mov(tmud, r0)                                         # delay slot
+        mov(tmua, reg_dst).add(reg_dst, reg_dst, reg_stride)  # delay slot
+
+    # This synchronization is needed between the last TMU operation and the
+    # program end with the thread switch just before the loop above.
+    barrierid(syncb, sig=thrsw)
+    nop()
+    nop()
+
+    nop(sig=thrsw)
+    nop(sig=thrsw)
+    nop()
+    nop()
+    nop(sig=thrsw)
+    nop()
+    nop()
+    nop()
+
+
+def scopy(*, length, num_qpus=8, unroll_shift=0):
+
+    assert length > 0
+    assert length % (16 * 8 * num_qpus * (1 << unroll_shift)) == 0
+
+    print(f'==== scopy example ({length / 1024 / 1024} Mi elements) ====')
+
+    with Driver(data_area_size=(length * 2 + 1024) * 4) as drv:
+
+        code = drv.program(qpu_scopy, num_qpus=num_qpus,
+                           unroll_shift=unroll_shift,
+                           code_offset=drv.code_pos // 8)
+
+        print('Preparing for buffers...')
+
+        X = drv.alloc(length, dtype='float32')
+        Y = drv.alloc(length, dtype='float32')
+
+        X[:] = np.arange(*X.shape, dtype=X.dtype)
+        Y[:] = -X
+
+        assert not np.array_equal(X, Y)
+
+        unif = drv.alloc(3, dtype='uint32')
+        unif[0] = length
+        unif[1] = X.addresses()[0]
+        unif[2] = Y.addresses()[0]
+
+        print('Executing on QPU...')
+
+        start = monotonic()
+        drv.execute(code, unif.addresses()[0], thread=num_qpus)
+        end = monotonic()
+
+        assert np.array_equal(X, Y)
+
+        print(f'{end - start} sec, {length * 4 / (end - start) * 1e-6} MB/s')
+
+
+def main():
+
+    scopy(length=16 * 1024 * 1024)
+
+
+if __name__ == '__main__':
+
+    main()

--- a/examples/summation.py
+++ b/examples/summation.py
@@ -1,0 +1,149 @@
+
+from time import monotonic
+
+import numpy as np
+
+from videocore6.assembler import qpu
+from videocore6.driver import Driver
+
+
+@qpu
+def qpu_summation(asm, *, num_qpus, unroll_shift, code_offset,
+                  align_cond=lambda pos: pos % 512 == 170):
+
+    g = globals()
+    for i, v in enumerate(['length', 'src', 'dst', 'qpu_num', 'stride', 'sum']):
+        g[f'reg_{v}'] = rf[i]
+
+    nop(sig=ldunifrf(reg_length))
+    nop(sig=ldunifrf(reg_src))
+    nop(sig=ldunifrf(reg_dst))
+
+    if num_qpus == 1:
+        num_qpus_shift = 0
+        mov(reg_qpu_num, 0)
+    elif num_qpus == 8:
+        num_qpus_shift = 3
+        tidx(r0)
+        shr(r0, r0, 2)
+        band(reg_qpu_num, r0, 0b1111)
+    else:
+        raise Exception('num_qpus must be 1 or 8')
+
+    # addr += 4 * (thread_num + 16 * qpu_num)
+    shl(r0, reg_qpu_num, 4)
+    eidx(r1)
+    add(r0, r0, r1)
+    shl(r0, r0, 2)
+    add(reg_src, reg_src, r0).add(reg_dst, reg_dst, r0)
+
+    # stride = 4 * 16 * num_qpus
+    mov(reg_stride, 1)
+    shl(reg_stride, reg_stride, 6 + num_qpus_shift)
+
+    # The QPU performs shifts and rotates modulo 32, so it actually supports
+    # shift amounts [0, 31] only with small immediates.
+    num_shifts = [*range(16), *range(-16, 0)]
+
+    # length /= 16 * 8 * num_qpus * unroll
+    shr(reg_length, reg_length, num_shifts[7 + num_qpus_shift + unroll_shift])
+
+    # This single thread switch and two instructions just before the loop are
+    # really important for TMU read to achieve a better performance.
+    # This also enables TMU read requests without the thread switch signal, and
+    # the eight-depth TMU read request queue.
+    nop(sig=thrsw)
+    nop()
+    bxor(reg_sum, 1, 1).mov(r1, 1)
+
+    while not align_cond(code_offset + len(asm)):
+        nop()
+
+    with loop as l:
+
+        unroll = 1 << unroll_shift
+
+        for i in range(7):
+            mov(tmua, reg_src).add(reg_src, reg_src, reg_stride)
+        mov(tmua, reg_src).sub(reg_length, reg_length, r1, cond='pushz')
+        add(reg_src, reg_src, reg_stride, sig=ldtmu(r0))
+
+        for j in range(unroll - 1):
+            for i in range(8):
+                mov(tmua, reg_src).add(reg_src, reg_src, reg_stride)
+                add(reg_sum, reg_sum, r0, sig=ldtmu(r0))
+
+        for i in range(5):
+            add(reg_sum, reg_sum, r0, sig=ldtmu(r0))
+
+        l.b(cond='na0')
+        add(reg_sum, reg_sum, r0, sig=ldtmu(r0))  # delay slot
+        add(reg_sum, reg_sum, r0, sig=ldtmu(r0))  # delay slot
+        add(reg_sum, reg_sum, r0)                 # delay slot
+
+    mov(tmud, reg_sum)
+    mov(tmua, reg_dst)
+
+    # This synchronization is needed between the last TMU operation and the
+    # program end with the thread switch just before the loop above.
+    barrierid(syncb, sig=thrsw)
+    nop()
+    nop()
+
+    nop(sig=thrsw)
+    nop(sig=thrsw)
+    nop()
+    nop()
+    nop(sig=thrsw)
+    nop()
+    nop()
+    nop()
+
+
+def summation(*, length, num_qpus=8, unroll_shift=5):
+
+    assert length > 0
+    assert length % (16 * 8 * num_qpus * (1 << unroll_shift)) == 0
+
+    print(f'==== summaton example ({length / 1024 / 1024} Mi elements) ====')
+
+    with Driver(data_area_size=(length + 1024) * 4) as drv:
+
+        code = drv.program(qpu_summation, num_qpus=num_qpus,
+                           unroll_shift=unroll_shift,
+                           code_offset=drv.code_pos // 8)
+
+        print('Preparing for buffers...')
+
+        X = drv.alloc(length, dtype='uint32')
+        Y = drv.alloc(16 * num_qpus, dtype='uint32')
+
+        X[:] = np.arange(length, dtype=X.dtype)
+        Y.fill(0)
+
+        assert sum(Y) == 0
+
+        unif = drv.alloc(3, dtype='uint32')
+        unif[0] = length
+        unif[1] = X.addresses()[0]
+        unif[2] = Y.addresses()[0]
+
+        print('Executing on QPU...')
+
+        start = monotonic()
+        drv.execute(code, unif.addresses()[0], thread=num_qpus)
+        end = monotonic()
+
+        assert sum(Y) % 2**32 == (length - 1) * length // 2 % 2**32
+
+        print(f'{end - start} sec, {length * 4 / (end - start) * 1e-6} MB/s')
+
+
+def main():
+
+    summation(length=32 * 1024 * 1024)
+
+
+if __name__ == '__main__':
+
+    main()


### PR DESCRIPTION
This PR adds these three more examples, which are mainly intended to measure TMU read/write performance:

- `summation.py`: Adds up 32-bit integers in an array, which measures TMU read performance.
- `memset.py`: Sets a single 32-bit value to an array, which measures TMU write performance.
- `scopy.py`: Copies an array, which measures TMU simultaneous read/write performance.

These examples run with the full eight QPUs, so the metrics can be seen as the upper bound of TMU performance.