### PR TITLE
drm: Explicitly specify the V3D DRI device by address

### DIFF
--- a/videocore6/drm_v3d.py
+++ b/videocore6/drm_v3d.py
@@ -25,8 +25,8 @@ from ioctl_opt import IOW, IOWR
 
 class DRM_V3D(object):
 
-    def __init__(self, n=0):
-        self.fd = os.open(f'/dev/dri/card{n}', os.O_RDWR)
+    def __init__(self, path='/dev/dri/by-path/platform-fec00000.v3d-card'):
+        self.fd = os.open(path, os.O_RDWR)
 
     def close(self):
         if self.fd is not None:


### PR DESCRIPTION
On some environments (c.f. https://github.com/Idein/py-videocore6/issues/48) the order of loading v3d and vc4 modules is sometimes swapped, so the device minor of v3d is not fixed to zero.
This pull request fixes to specify the v3d device by its hardware address.