### PR TITLE
drm: Select device by minor number, not physical address

### DIFF
--- a/videocore6/drm_v3d.py
+++ b/videocore6/drm_v3d.py
@@ -25,7 +25,7 @@ from ioctl_opt import IOW, IOWR
 
 class DRM_V3D(object):
 
-    def __init__(self, path='/dev/dri/by-path/platform-fec00000.v3d-card'):
+    def __init__(self, path='/dev/dri/card0'):
         self.fd = os.open(path, os.O_RDWR)
 
     def close(self):


### PR DESCRIPTION
Selecting the device by physical address, which was implemented by commit 02c72528886a ("drm: Explicitly specify the V3D DRI device by address"), is a robust way to specify the device.
However, a number of our softwares assumes the device appears as /dev/dri/card0, so this commit reverts the previous one and adds an ability to specify the full device path instead of the card number.

c.f. https://github.com/Idein/py-videocore6/pull/49